### PR TITLE
Do not interpret TFTP filename as absolute url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,15 @@ For other platforms or to build from source, clone the repository and just run `
 
     Usage of dist/tftp-http-proxy:
       -http-base-url string
-        	HTTP base URL (default "http://127.0.0.1/tftp")
+                HTTP base URL (default "http://127.0.0.1/tftp")
+      -http-append-path
+                Append path to url (add slash and then requested path), warning
+                no path sanitization is done, so it may contain /../ or other
+                wild characters.
       -tftp-timeout duration
-        	TFTP timeout (default 5s)
+                TFTP timeout (default 5s)
+      -tftp-bind-address address
+                UDP address to bind to
 
 ## Details
 


### PR DESCRIPTION
With `-http-append-path` TFTP request `//foo/bar` discars path portion of base url and `http://foo/bar` made request to server `foo` completely ignoring base url.
This patch validates base url on start and does not interpret TFTP filename in any special way.
It just strips *all* leading slashes and appends it to base url when `-http-append-path` is enabled.

Reproducing error on previous version of tftp-http-proxy: `curl tftp://localhost/http://example.com/` (provided that tftp-http-proxy has access to internet).